### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ fall back to taking the filesystem timestamp into account.
   file push and will instead be replaced. This can also be set on a
   per-resource level in the configuration file.
 
-- `--keep-transations`: If present, translations of source strings with the
+- `--keep-translations`: If present, translations of source strings with the
   same key whose content changes will not be discarded. This can also be set on
   a per-resource level in the configuration file.
 


### PR DESCRIPTION
This tricks me because It does not work when copy from the README.md